### PR TITLE
Add license refrence to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,8 @@
 * Argonaut - http://argonaut.io
 * Http4S - http://http4s.org
 * Spark Connectors - [Cassandra](https://github.com/datastax/spark-cassandra-connector)
+
+
+## License
+
+This project is licensed under the Apache-2.0 license - see the [LICENSE](https://github.com/nokia/wookie/blob/master/LICENSE).


### PR DESCRIPTION
Adds a refrence to the project license to README.md. This is considered a best-practice.